### PR TITLE
T7995 - Melhorias no Multiphono (menus, testes)

### DIFF
--- a/stock_storage_type/__manifest__.py
+++ b/stock_storage_type/__manifest__.py
@@ -20,7 +20,8 @@
         "views/stock_location.xml",
         "views/stock_location_storage_type.xml",
         "views/stock_package_storage_type.xml",
-        "views/stock_picking.xml",
+        # "views/stock_picking.xml",  # View obsoleta, alterada para o stock_move.xml
+        "views/stock_move.xml",
         "views/storage_type_menus.xml",
     ],
     "demo": [

--- a/stock_storage_type/views/stock_move.xml
+++ b/stock_storage_type/views/stock_move.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <record id="view_picking_details_move_tree" model="ir.ui.view">
+        <field name="name">stock.picking.details.move.tree</field>
+        <field name="model">stock.move</field>
+        <field name="inherit_id" ref="stock.view_picking_details_move_tree"/>
+        <field name="arch" type="xml">
+            <xpath expr="//button[@name='action_show_details']" position="before">
+                <field name="product_packaging" domain="[('product_id', '=', product_id)]" />
+            </xpath>
+        </field>
+    </record>
+</odoo>


### PR DESCRIPTION
# Descrição

- Altera herança da tree de stock.move no stock.picking
  - A tree era criada no xml dentro do campo 'move_ids_without_package' da tabela 'stock.picking', mas foi alterado no próprio core, e separado em uma view específica com um id xml.

# Informações adicionais

- [T7995](https://multi.multidados.tech/web?#id=8404&action=323&active_id=61&model=project.task&view_type=form&menu_id=223)

PR relacionado:
- [core](https://github.com/multidadosti-erp/odoo/pull/246)
- [muk](https://github.com/multidadosti-erp/muk-addons/pull/37)
- [l10n_br](https://github.com/multidadosti-erp/odoo-brasil-addons/pull/1364)
- private-addons